### PR TITLE
11: changed error handler to HttpGet

### DIFF
--- a/recipe-api/Controllers/ErrorsController.cs
+++ b/recipe-api/Controllers/ErrorsController.cs
@@ -4,7 +4,7 @@ namespace Recipe.Controllers;
 
 public class ErrorsController : ControllerBase {
 
-    [Route("/error")]
+    [HttpGet("/error")]
     public IActionResult Error(){
         return Problem();
     }


### PR DESCRIPTION
Quick fix to make swagger page load up... previously it wasn't because the error handler endpoint did not have an HTTP method assigned to it

Closes #11 